### PR TITLE
Add MIT license and reference in docs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 PaceBuddy contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PaceBuddy ReImagined.md
+++ b/PaceBuddy ReImagined.md
@@ -127,3 +127,6 @@ Want me to:
 - add **QLab/OSC/MIDI** adapter event types (even if Phase 2), or
     
 - generate a **minimal Node/Express + ws stub** that validates messages against this schema and broadcasts?
+## License
+
+This project is licensed under the [MIT License](LICENSE.md).

--- a/pbr-OverviewAndVision.md
+++ b/pbr-OverviewAndVision.md
@@ -39,4 +39,6 @@ This repo currently contains:
 ---
 
 ## License
-TBD
+
+This project is licensed under the [MIT License](LICENSE.md).
+


### PR DESCRIPTION
## Summary
- add MIT License file
- reference license in main overview docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cad39b7588324a01dd1ada1f69963