### PR TITLE
Add ShowEvent schema validation tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pacebuddy",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "ajv": "^8.12.0"
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# JSON Schema Tests
+
+This suite validates example `ShowEvent` JSON Lines against the `schema/show-event.schema.json` definition using [Ajv](https://ajv.js.org/).
+
+## Running
+
+```sh
+npm install
+npm test
+```
+
+## Expected Results
+
+All tests should pass, confirming the example flow conforms to the schema.

--- a/tests/fixtures/show-event-flow.jsonl
+++ b/tests/fixtures/show-event-flow.jsonl
@@ -1,0 +1,2 @@
+{"kind":"event","version":"1.0","messageId":"11111111-1111-1111-1111-111111111111","eventType":"CueAdvanced","showId":"show-123","createdAt":"2024-01-01T00:00:00Z","actor":{"userId":"user-1","role":"director","deviceId":"dev-1"},"payload":{}}
+{"kind":"event","version":"1.0","messageId":"22222222-2222-2222-2222-222222222222","eventType":"MicAssigned","showId":"show-123","createdAt":"2024-01-01T00:01:00Z","actor":{"userId":"user-2","role":"stage-manager","deviceId":"dev-2"},"payload":{"micId":"mic-1"}}

--- a/tests/show-event.test.js
+++ b/tests/show-event.test.js
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert';
+import Ajv from 'ajv';
+
+const schemaPath = join('schema', 'show-event.schema.json');
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+const filePath = join('tests', 'fixtures', 'show-event-flow.jsonl');
+const lines = readFileSync(filePath, 'utf8').trim().split('\n');
+
+test('ShowEvent JSONL flow matches schema', () => {
+  for (const [index, line] of lines.entries()) {
+    const event = JSON.parse(line);
+    const valid = validate(event);
+    assert.ok(valid, `Line ${index + 1} failed validation: ${ajv.errorsText(validate.errors)}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add Ajv-based test to validate ShowEvent JSONL fixtures
- document how to run schema tests
- add CI workflow to run tests

## Testing
- `npm test` *(fails: Cannot find package 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_689cc14ff0cc8324ae34067fc95360c8