### PR TITLE
Add Mocha-based JSONL schema validation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test tests"
   },
   "devDependencies": {
     "ajv": "^8.12.0"

--- a/server/package.json
+++ b/server/package.json
@@ -5,9 +5,13 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node -e \"console.log('No tests specified')\""
+    "test": "mocha"
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "ajv": "^8.12.0",
+    "mocha": "^10.2.0"
+  }
 }

--- a/server/test/flow.test.js
+++ b/server/test/flow.test.js
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert/strict';
+import Ajv from 'ajv/dist/2020.js';
+
+describe('JSONL flow validation', () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const rootDir = join(__dirname, '..', '..');
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const showEventSchema = JSON.parse(readFileSync(join(rootDir, 'schema', 'show-event.schema.json'), 'utf8'));
+  const wireMessageSchema = JSON.parse(readFileSync(join(rootDir, 'schema', 'wire-message.schema.json'), 'utf8'));
+  const validateShow = ajv.compile(showEventSchema);
+  const validateWire = ajv.compile(wireMessageSchema);
+  const lines = readFileSync(join(rootDir, 'tests', 'fixtures', 'show-event-flow.jsonl'), 'utf8')
+    .trim()
+    .split('\n');
+  it('matches show-event schema', () => {
+    for (const [index, line] of lines.entries()) {
+      const event = JSON.parse(line);
+      const valid = validateShow(event);
+      assert.ok(valid, `Line ${index + 1} failed: ${ajv.errorsText(validateShow.errors)}`);
+    }
+  });
+  it('matches wire-message schema', () => {
+    for (const [index, line] of lines.entries()) {
+      const event = JSON.parse(line);
+      const valid = validateWire(event);
+      assert.ok(valid, `Line ${index + 1} failed: ${ajv.errorsText(validateWire.errors)}`);
+    }
+  });
+});

--- a/tests/show-event.test.js
+++ b/tests/show-event.test.js
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import test from 'node:test';
 import assert from 'node:assert';
-import Ajv from 'ajv';
+import Ajv from 'ajv/dist/2020.js';
 
 const schemaPath = join('schema', 'show-event.schema.json');
 const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));


### PR DESCRIPTION
## Summary
- add Mocha and Ajv to server package and wire into npm test
- add tests validating JSONL flows against show-event and wire-message schemas
- update root tests to use Ajv 2020 and restrict test path

## Testing
- `npm test` *(fails: sh: 1: mocha: not found)*
- `npm test` (in repo root)


------
https://chatgpt.com/codex/tasks/task_e_689cc3a40b748324bfdfebc72c7e0b55